### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,19 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER) docs/_build/html/index.html
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	pip install -q pip-tools
-	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)
+	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+	pip install -qr requirements/pip-tools.txt
+	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/dev.txt requirements/dev.in requirements/quality.in
 	pip-compile --rebuild --upgrade -o requirements/doc.txt requirements/base.in requirements/doc.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,7 @@
 # linking to it here is good.
 
 # Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
 
 # Required to avoid ImportError https://github.com/sphinx-contrib/sphinxcontrib-versioning/issues/66
 sphinx<=1.8.5

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,7 +3,6 @@
 -c constraints.txt
 
 edx-lint                  # For updating pylintrc
-pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 twine                     # Utility for PyPI package uploads

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,8 +12,6 @@ bleach==5.0.0
     # via readme-renderer
 certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via requests
 click==8.1.3
@@ -21,15 +19,12 @@ click==8.1.3
     #   click-log
     #   code-annotations
     #   edx-lint
-    #   pip-tools
 click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==37.0.2
-    # via secretstorage
 dill==0.3.5.1
     # via pylint
 distlib==0.3.4
@@ -54,10 +49,6 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.3
     # via
     #   -c requirements/constraints.txt
@@ -74,10 +65,6 @@ packaging==21.3
     # via tox
 pbr==5.9.0
     # via stevedore
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
-    # via -r requirements/dev.in
 pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
@@ -90,8 +77,6 @@ py==1.11.0
     # via tox
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.12.0
@@ -130,8 +115,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -147,9 +130,7 @@ text-unidecode==1.3
 toml==0.10.2
     # via tox
 tomli==2.0.1
-    # via
-    #   pep517
-    #   pylint
+    # via pylint
 tomlkit==0.11.0
     # via pylint
 tox==3.25.0
@@ -174,14 +155,11 @@ virtualenv==20.14.1
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
-    # via
-    #   -r requirements/dev.in
-    #   pip-tools
+    # via -r requirements/dev.in
 wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,14 +14,10 @@ build==0.8.0
     # via -r requirements/doc.in
 certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via requests
 commonmark==0.9.1
     # via rich
-cryptography==37.0.2
-    # via secretstorage
 doc8==0.11.2
     # via -r requirements/doc.in
 docutils==0.18.1
@@ -38,10 +34,6 @@ importlib-metadata==4.11.4
     # via
     #   keyring
     #   twine
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.3
     # via
     #   -c requirements/constraints.txt
@@ -60,8 +52,6 @@ pep517==0.12.0
     # via build
 pkginfo==1.8.3
     # via twine
-pycparser==2.21
-    # via cffi
 pygments==2.12.0
     # via
     #   doc8
@@ -87,8 +77,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/base.in

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,0 +1,3 @@
+-c constraints.txt
+
+pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
+click==8.1.3
+    # via pip-tools
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.6.2
+    # via -r requirements/pip-tools.in
+tomli==2.0.1
+    # via pep517
 wheel==0.37.1
-    # via -r requirements/pip.in
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
-    # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+# pip
+# setuptools


### PR DESCRIPTION
Added pip-tools requirements files and updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.