### PR TITLE
fix: remove codecov from requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='sphinx50'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
+        files: htmlcov/index.html
         fail_ci_if_error: true

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.13
-    # via -r requirements/ci.in
-coverage==7.2.3
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.1
     # via tox
 platformdirs==3.2.0
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.22.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -12,8 +12,6 @@ bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==3.1.0
     # via requests
 click==8.1.3
@@ -25,8 +23,6 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-cryptography==40.0.2
-    # via secretstorage
 dill==0.3.6
     # via pylint
 distlib==0.3.6
@@ -43,7 +39,7 @@ filelock==3.12.0
     #   virtualenv
 idna==3.4
     # via requests
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   twine
@@ -55,10 +51,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via code-annotations
 keyring==23.13.1
@@ -91,15 +83,13 @@ py==1.11.0
     # via tox
 pycodestyle==2.10.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.15.1
     # via
     #   readme-renderer
     #   rich
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -129,8 +119,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,12 +14,8 @@ build==0.10.0
     # via -r requirements/doc.in
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==40.0.2
-    # via secretstorage
 doc8==1.1.1
     # via -r requirements/doc.in
 docutils==0.19
@@ -32,7 +28,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   sphinx
@@ -41,10 +37,6 @@ importlib-resources==5.12.0
     # via keyring
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 keyring==23.13.1
@@ -65,8 +57,6 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-pycparser==2.21
-    # via cffi
 pygments==2.15.1
     # via
     #   doc8
@@ -92,8 +82,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/base.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1
+pip==23.1.1
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -41,7 +41,7 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via sphinx
 iniconfig==2.0.0
     # via pytest

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test --cov {envsitepackagesdir}/edx_theme {posargs}
+    python -m coverage html
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn’t depend on the package so our CI coverage won’t be affected by the change.